### PR TITLE
Improving Orders View

### DIFF
--- a/lib/views/orders_overview.dart
+++ b/lib/views/orders_overview.dart
@@ -5,46 +5,40 @@ import '../providers/orders.dart' show Orders;
 import '../widgets/layouts/app_drawer.dart';
 import '../widgets/order_item.dart';
 
-class OrdersOverview extends StatefulWidget {
+class OrdersOverview extends StatelessWidget {
   static const routeName = '/orders';
 
   const OrdersOverview({super.key});
 
   @override
-  State<OrdersOverview> createState() => _OrdersOverviewState();
-}
-
-class _OrdersOverviewState extends State<OrdersOverview> {
-  bool _isLoading = false;
-
-  @override
-  void initState() {
-    Future.delayed(Duration.zero).then((_) {
-      setState(() {
-        _isLoading = true;
-      });
-      Provider.of<Orders>(context, listen: false).fetchAndSetOrders();
-      setState(() {
-        _isLoading = false;
-      });
-    });
-    super.initState();
-  }
-
-  @override
   Widget build(BuildContext context) {
-    final orders = Provider.of<Orders>(context);
     return Scaffold(
       appBar: AppBar(
         title: const Text('Your Orders'),
       ),
       drawer: const AppDrawer(),
-      body: _isLoading
-          ? const Center(child: CircularProgressIndicator())
-          : ListView.builder(
-              itemCount: orders.orders.length,
-              itemBuilder: (ctx, index) => OrderItem(orders.orders[index]),
-            ),
+      body: FutureBuilder(
+        future: Provider.of<Orders>(context, listen: false).fetchAndSetOrders(),
+        builder: (ctx, dataSnapshot) {
+          if (dataSnapshot.connectionState == ConnectionState.waiting) {
+            return const Center(child: CircularProgressIndicator());
+          } else {
+            if (dataSnapshot.error != null) {
+              return const Center(
+                child: Text('Something goes wrong'),
+              );
+            } else {
+              return Consumer<Orders>(
+                builder: (ctx, orderData, _) => ListView.builder(
+                  itemCount: orderData.orders.length,
+                  itemBuilder: (ctx, index) =>
+                      OrderItem(orderData.orders[index]),
+                ),
+              );
+            }
+          }
+        },
+      ),
     );
   }
 }


### PR DESCRIPTION
Using Future Builder as alternative to fetch products because there are no interactions between user and orders other than fetch orders in this screen. This turns this view into Stateless even awaiting results from request